### PR TITLE
change wording for more readability

### DIFF
--- a/chapters/3.FreeCAD Base and App module.md
+++ b/chapters/3.FreeCAD Base and App module.md
@@ -385,10 +385,10 @@ Quantity string can be parsed into value and unit by *quantitylexer*
 
 ## Property framewrok
 
-see Doxygen generated document for example of using the property framework. However, module developer needs not to know such low level details.
+see Doxygen generated document for example of using the property framework. However, module developers don't need to know about the details on such low levels.
 It's like the reflection mechanism of Java or C#.   This ability is introduced by the App::PropertyContainer class and can be used by all derived classes.
 
-This makes it possible in the first place to make an automatic mapping to python (e.g. in App::FeaturePy) and abstract editing properties in Gui::PropertyEditor.
+This makes an automatic mapping to python (e.g. in App::FeaturePy) possible as well as abstract editing properties in Gui::PropertyEditor.
 
 Access property in Python is easier than c++, which needs a `static_cast<>` for type conversion (downcast)
 
@@ -1027,7 +1027,7 @@ static void Application::runApplication()
 This source will be compiled into the program "freecad", which will take you FreeCAD GUI.
 
 This main function is similar with [src/Main/MainCmd.cpp], except it supports both Gui and nonGui mode
-*App::Application::init(argc, argv); * and    *App::Application::destruct(); * are still called!
+*App::Application::init(argc, argv);* and    *App::Application::destruct();* are still called!
 
 QCoreApplication is defined for WIN32, see [src/Main/MainGui.cpp], text banner is defined here
 
@@ -1056,8 +1056,7 @@ main()
 
 Constructor of Gui::Application: setting up Python binding
 
-```
-
+```cpp
 /** Override QCoreApplication::notify() to fetch exceptions in Qt widgets
  * properly that are not handled in the event handler or slot.
  */


### PR DESCRIPTION
I changed the wording in a few places and one code listing is now highlighted in cpp styel